### PR TITLE
Silent crash of Node

### DIFF
--- a/deps/blpapi/include-3.8.1.1/blpapi_exception.h
+++ b/deps/blpapi/include-3.8.1.1/blpapi_exception.h
@@ -406,7 +406,7 @@ void ExceptionUtil::throwException(int errorCode)
       case BLPAPI_NOTFOUND_CLASS:
         throw NotFoundException(description);
       default:
-        throw Exception(description);
+        throw UnknownErrorException(description);
     }
 }
 


### PR DESCRIPTION
Exception type seems to not be catched by the try/catch in blpapi.js